### PR TITLE
Remove extraneous " from github-app.private-key

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -38,7 +38,7 @@ data:
     {{ end }}
     {{- if .Values.github.privateKey }}
     github-app.private-key: |-
-      {{ .Values.github.privateKey | nindent 8 }}"
+      {{ .Values.github.privateKey | nindent 8 }}
     {{ end }}
     {{- if .Values.github.webhookSecret }}
     github-app.webhook-secret: "{{ .Values.github.webhookSecret }}"


### PR DESCRIPTION
The `github-app.private-key` key in the configmap for the Sentry configuration currently has an extra `"` that shouldn't be there, which results in the Sentry backend being unable to parse the private key.